### PR TITLE
feat(core): support for text summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # summarizeback
 
-
 ### Setting up a Virtual Environment
 
 **Note: It's recommended to create the virtual environment (venv) within the project directory. To do so, navigate to the project directory using the `cd` command and then proceed with the following instructions.**
@@ -33,11 +32,19 @@ nltk.download('punkt')
 1. Activate the venv
 2. Start the `flask` app -> `flask run`
 3. Make a POST request to `/summarize` endpoint.
-You can send 2 params
+You can send 3 params
 1 -> url
-2 -> length -> defaults to 15
+2 -> raw text
+3 -> length -> defaults to 15
+> If both url and text are provided it will summarize the url content.
+1. URL Summarization
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{"url": "https://example.com"}' http://127.0.0.1:5000/summarize
+```
+2. Text Summarization
+> Make sure while testing from the CLI you don't want the new line character in your json payload
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"text": "The Domain Name System (DNS) is a hierarchical and distributed naming system for computers, services, and other resources in the Internet or other Internet Protocol (IP) networks. It associates various information with domain names (identification strings) assigned to each of the associated entities. Most prominently, it translates readily memorized domain names to the numerical IP addresses needed for locating and identifying computer services and devices with the underlying network protocols.[1] The Domain Name System has been an essential component of the functionality of the Internet since 1985.", "length": "3"}' http://127.0.0.1:5000/summarize
 ```
 OR
 Use the provided `test.html` to make your life easier.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
 
+from sumy.parsers.plaintext import PlaintextParser
 from sumy.parsers.html import HtmlParser
 from sumy.nlp.tokenizers import Tokenizer
 from sumy.summarizers.lsa import LsaSummarizer as Summarizer
@@ -15,9 +16,29 @@ app = Flask(__name__)
 CORS(app)
 LANGUAGE = "english"
 
+'''
+I am aware of the code duplication for `text and url` summarization,
+it was intentional as if I don't do that and try to make the code more
+generic then the HTMLParser content has to be manually parsed in text
+which is more computationally heavy.
+'''
 
-def get_summary(url, sentences_count):
+
+def get_url_summary(url, sentences_count):
     parser = HtmlParser.from_url(url, Tokenizer(LANGUAGE))
+    stemmer = Stemmer(LANGUAGE)
+
+    summarizer = Summarizer(stemmer)
+    summarizer.stop_words = get_stop_words(LANGUAGE)
+
+    summarized_text = ""
+    for sentence in summarizer(parser.document, sentences_count):
+        summarized_text += str(sentence) + " "
+    return summarized_text
+
+
+def get_text_summary(text, sentences_count):
+    parser = PlaintextParser.from_string(text, Tokenizer(LANGUAGE))
     stemmer = Stemmer(LANGUAGE)
 
     summarizer = Summarizer(stemmer)
@@ -33,20 +54,18 @@ def get_summary(url, sentences_count):
 def main():
     try:
         data = request.get_json()
-        url = data.get("url")
         length = data.get("length") or 15
+        url = data.get("url")
+        raw_text = data.get("text")
 
-        if not url:
-            return jsonify(
-                {"error": "Please provide a valid URL in the request body"}),
-            400
+        if not url and not raw_text:
+            return jsonify({"error": "You have to provide Something"}), 400
+        if url:
+            summarized_text = get_url_summary(url, length)
+        else:
+            summarized_text = get_text_summary(raw_text, length)
 
-        summarized_text = get_summary(url, length)
         return jsonify({"summarized_text": summarized_text})
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500
-
-
-if __name__ == "__main__":
-    app.run(debug=True)

--- a/test.html
+++ b/test.html
@@ -8,22 +8,27 @@
 <body>
     <h1>A Shitty Summarization tool</h1>
 
-    <form id="urlForm">
+    <form id="inputForm">
         <label for="urlInput">Enter URL:</label>
-        <input type="text" id="urlInput" name="url" required>
+        <input type="text" id="urlInput" name="url">
         <label for="length">Summary Length:</label>
         <input type="number" id="length" name="length" required>
-        <button type="submit" id="summary">Summarize</button>
+        <button type="submit" id="summaryURL">Summarize URL</button>
     </form>
 
+    <form id="textForm">
+        <label for="textInput">Paste Text:</label>
+        <textarea id="textInput" name="text" rows="5" cols="50"></textarea>
+        <button type="submit" id="summaryText">Summarize Text</button>
+    </form>
 
     <div class="result">
         <h2>Summarized Text:</h2>
-        <p id="SummarizedText"></p>
+        <p id="summarizedText"></p>
     </div>
 
     <script>
-        document.getElementById("summary").addEventListener("click", function(event) {
+        document.getElementById("summaryURL").addEventListener("click", function(event) {
             event.preventDefault();
 
             const url = document.getElementById("urlInput").value;
@@ -37,16 +42,37 @@
             })
             .then(response => response.json())
             .then(data => {
-                document.getElementById("SummarizedText").textContent = data.summarized_text;
+                document.getElementById("summarizedText").textContent = data.summarized_text;
             })
             .catch(error => {
                 console.error('Error:', error);
                 console.log('Response Status:', error.response.status);
                 console.log('Response Text:', error.response.statusText);
             });
+        });
 
+        document.getElementById("summaryText").addEventListener("click", function(event) {
+            event.preventDefault();
+
+            const text = document.getElementById("textInput").value;
+            const length = document.getElementById("length").value;
+            fetch('http://localhost:5000/summarize', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ 'text': text, 'length': +length }),
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById("summarizedText").textContent = data.summarized_text;
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                console.log('Response Status:', error.response.status);
+                console.log('Response Text:', error.response.statusText);
+            });
         });
     </script>
 </body>
 </html>
-


### PR DESCRIPTION
This shit might contain several bugs but who cares.

- Now the `endpoint` reads for 3 params
    1. url
    2. text
    3. length

- If both the url and text are provided to the endpoint it will
  summarize the url.

- I am aware of the code duplication for `text and url` summarization,
  it was intentional as if I don't do that and try to make the code more
  generic then the HTMLParser content has to be manually parsed in text
  which is more computationally heavy.